### PR TITLE
path fixed

### DIFF
--- a/tools/grammar-gen.sh
+++ b/tools/grammar-gen.sh
@@ -19,5 +19,5 @@ fi
 
 
 cd ..
-java -jar tools/JFlex.jar --sliceandcharat --skel /Users/mozg/Projects/IDE/intellij-community/tools/lexer/idea-flex.skeleton -d gen/org/plantuml/idea/lang/parser src/org/plantuml/idea/lang/parser/PlantUml.flex
+java -jar tools/JFlex.jar --sliceandcharat --skel tools/idea-flex.skeleton -d gen/org/plantuml/idea/lang/parser src/org/plantuml/idea/lang/parser/PlantUml.flex
 java -jar tools/GrammarKit/lib/grammar-kit.jar gen src/org/plantuml/idea/lang/parser/PlantUml.bnf


### PR DESCRIPTION
Is this how it should work?

```
Meo@MEO-PC /f/workspace/_projekty/Github/plantuml4idea (highlighting)
$ ./tools/grammar-gen.sh
Archive:  GrammarKit.zip
   creating: GrammarKit/
   creating: GrammarKit/lib/
  inflating: GrammarKit/lib/grammar-kit.jar
Reading skeleton file "tools\idea-flex.skeleton".
Reading "src\org\plantuml\idea\lang\parser\PlantUml.flex"

Warning : Macro "WHITE_SPACE_CHAR" has been declared but never used.
Constructing NFA : 975 states in NFA
Converting NFA to DFA :
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................
1750 states before minimization, 610 states in minimized DFA
Old file "gen\org\plantuml\idea\lang\parser\_PlantUmlLexer.java" saved as "gen\o
rg\plantuml\idea\lang\parser\_PlantUmlLexer.java~"
Writing code to "gen\org\plantuml\idea\lang\parser\_PlantUmlLexer.java"
No grammars matching 'src/org/plantuml/idea/lang/parser/PlantUml.bnf' found in:
.
```
